### PR TITLE
Added mandatory office to invoice header

### DIFF
--- a/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
+++ b/src/Pronamic/Twinfield/Invoice/DOM/InvoicesDocument.php
@@ -88,6 +88,7 @@ class InvoicesDocument extends \DOMDocument
 
         // Elements and their associated methods for invoice
         $headerTags = array(
+            'office'               => 'getOffice',
             'invoicetype'          => 'getInvoiceType',
             'invoicenumber'        => 'getInvoiceNumber',
             'status'               => 'getStatus',


### PR DESCRIPTION
Office is a mandatory field in the Header section of a Sales Invoice: https://c3.twinfield.com/webservices/documentation/#/ApiReference/SalesInvoices